### PR TITLE
Add Scryfall downloader command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Magic Deck Printer
 
-This project creates printable PDFs for Magic cards stored as images. The
-script reads all images inside `deck-to-print/` and generates two files:
-`fronts.pdf` and `backs.pdf`. They have the same layout so they can be
-printed in duplex mode.
+This project creates printable PDFs for Magic cards. It can download card images using the Scryfall API and then generate PDF files ready for duplex printing.
 
 ## Requirements
 
@@ -11,11 +8,12 @@ printed in duplex mode.
 - [Pillow](https://pypi.org/project/Pillow/)
 - [ReportLab](https://pypi.org/project/reportlab/)
 - [PyYAML](https://pypi.org/project/PyYAML/)
+- [requests](https://pypi.org/project/requests/)
 
 Install them with:
 
 ```bash
-pip install Pillow reportlab PyYAML
+pip install Pillow reportlab PyYAML requests
 ```
 
 ## Configuration
@@ -30,23 +28,29 @@ GRID: [2, 5]             # [columns, rows]
 MARGIN_MM: 5             # margin on all sides
 GAP_MM: 2                # space between cards
 DEFAULT_BACK: back.jpg   # default back image in project root
+language-default: es     # preferred language for downloads
 ```
 
-Place your card images in `deck-to-print/` with names like:
+## Preparing card images
+
+Create a `card-list.txt` file listing the cards to download:
 
 ```
-4 Swamp.jpg       # print this image 4 times
-F01 Card Front.jpg
-B01 Card Back.jpg
+2 Swamp
+3 Island
 ```
 
-`F` indicates the front of a two-sided card and `B` the matching back with
-the same numeric identifier. Cards without a specific back will use the
-`DEFAULT_BACK` image.
+Run the downloader to populate `deck-to-print/` with the required images:
 
-## Usage
+```bash
+python fetch_images.py
+```
 
-Run the generator from the project root:
+Images of cards with a different back will be stored in matching `F##` and `B##` files.
+
+## Generating the PDFs
+
+Once the images are in place, run:
 
 ```bash
 python generate_pdf.py

--- a/card-list.txt
+++ b/card-list.txt
@@ -1,0 +1,2 @@
+2 Swamp
+3 Island

--- a/config.yml
+++ b/config.yml
@@ -5,3 +5,4 @@ GRID: [2, 5]  # columns, rows
 MARGIN_MM: 5
 GAP_MM: 2
 DEFAULT_BACK: back.jpg
+language-default: es

--- a/fetch_images.py
+++ b/fetch_images.py
@@ -1,0 +1,81 @@
+import os
+import re
+import requests
+import yaml
+
+CONFIG_FILE = 'config.yml'
+DECK_DIR = 'deck-to-print'
+CARD_LIST_FILE = 'card-list.txt'
+
+
+def load_config():
+    with open(CONFIG_FILE, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def parse_card_list(path=CARD_LIST_FILE):
+    cards = []
+    if not os.path.exists(path):
+        return cards
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            m = re.match(r'^(\d+)\s+(.+)$', line)
+            if not m:
+                continue
+            qty = int(m.group(1))
+            name = m.group(2)
+            cards.append((qty, name))
+    return cards
+
+
+def download_image(url, dest):
+    resp = requests.get(url)
+    resp.raise_for_status()
+    with open(dest, 'wb') as f:
+        f.write(resp.content)
+
+
+def fetch_images():
+    cfg = load_config()
+    lang = cfg.get('language-default', 'es')
+    cards = parse_card_list()
+    os.makedirs(DECK_DIR, exist_ok=True)
+    pair_id = 1
+    for qty, name in cards:
+        card_data = None
+        for language in (lang, 'en'):
+            r = requests.get(
+                'https://api.scryfall.com/cards/named',
+                params={'exact': name, 'lang': language},
+            )
+            if r.status_code == 200:
+                card_data = r.json()
+                break
+        if not card_data:
+            print(f'Card not found: {name}')
+            continue
+
+        if 'image_uris' in card_data:
+            img_url = card_data['image_uris'].get('png') or card_data['image_uris'].get('large')
+            fname = f"{qty} {card_data['name']}.png"
+            path = os.path.join(DECK_DIR, fname)
+            download_image(img_url, path)
+        elif 'card_faces' in card_data and len(card_data['card_faces']) >= 2:
+            front = card_data['card_faces'][0]
+            back = card_data['card_faces'][1]
+            for _ in range(qty):
+                ident = f"{pair_id:02d}"
+                fpath = os.path.join(DECK_DIR, f"F{ident} {front['name']}.png")
+                bpath = os.path.join(DECK_DIR, f"B{ident} {back['name']}.png")
+                download_image(front['image_uris'].get('png') or front['image_uris'].get('large'), fpath)
+                download_image(back['image_uris'].get('png') or back['image_uris'].get('large'), bpath)
+                pair_id += 1
+        else:
+            print(f'No images for card: {name}')
+
+
+if __name__ == '__main__':
+    fetch_images()


### PR DESCRIPTION
## Summary
- add script to download card images from Scryfall
- document new fetch step
- add language setting to config
- include example card list and image directory placeholder

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684634d7df248331b7ab4d2a3a7252de