### PR TITLE
Fix back page mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,6 @@ python generate_pdf.py
 
 PDF files will be created inside the `results/` directory with a name based on
 the current date and time, for example `deck_20230101_120000_fronts.pdf` and
-`deck_20230101_120000_backs.pdf`. Print them using the "flip on long edge"
-duplex option so that fronts and backs align.
+`deck_20230101_120000_backs.pdf`. The back pages are mirrored horizontally so
+that fronts and backs line up when cutting. Print using the "flip on long edge"
+duplex option to ensure proper alignment.

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -108,7 +108,10 @@ def draw_pages(pdf_path, pages, config, front=True):
         for idx, card in enumerate(page):
             col = idx % cols
             row = idx // cols
-            x = margin + col * (cell_width + gap)
+            if front:
+                x = margin + col * (cell_width + gap)
+            else:
+                x = margin + (cols - 1 - col) * (cell_width + gap)
             y = page_height - margin - cell_height - row * (cell_height + gap)
             img_path = card['front'] if front else card['back']
             img = Image.open(img_path)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -85,3 +85,33 @@ def test_parse_deck(monkeypatch, gp, tmp_path):
     assert len(swamps) == 2
     assert fronts[0]['back'].endswith('B01 Card Back.jpg')
     assert all(c['back'] == str(default_back) for c in swamps)
+
+
+def test_draw_pages_back_mirrored(monkeypatch, gp):
+    positions = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            positions.append((x, y))
+        def showPage(self):
+            pass
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (100, 100),
+        'margin_pt': 0,
+        'gap_pt': 0,
+        'card_width_pt': 10,
+        'card_height_pt': 20,
+        'GRID': (2, 1),
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}, {'front': 'f2', 'back': 'b2'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
+
+    assert [p[0] for p in positions] == [10, 0]


### PR DESCRIPTION
## Summary
- mirror card backs horizontally during PDF generation
- document the mirroring behaviour in the README
- test that back pages are mirrored correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684654ccbe708331b79d95359032e362