### PR TITLE
Fix back page mirroring when margins differ

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -103,6 +103,10 @@ def draw_pages(pdf_path, pages, config, front=True):
     cell_width = config['card_width_pt']
     cell_height = config['card_height_pt']
 
+    extra_x = page_width - 2 * margin - cols * cell_width - (cols - 1) * gap
+    extra_x = max(0, extra_x)
+    right_margin = margin + extra_x
+
     c = canvas.Canvas(pdf_path, pagesize=page_size)
     for page in pages:
         for idx, card in enumerate(page):
@@ -111,7 +115,7 @@ def draw_pages(pdf_path, pages, config, front=True):
             if front:
                 x = margin + col * (cell_width + gap)
             else:
-                x = margin + (cols - 1 - col) * (cell_width + gap)
+                x = right_margin + (cols - 1 - col) * (cell_width + gap)
             y = page_height - margin - cell_height - row * (cell_height + gap)
             img_path = card['front'] if front else card['back']
             img = Image.open(img_path)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -103,8 +103,8 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
     cfg = {
-        'page_size': (100, 100),
-        'margin_pt': 0,
+        'page_size': (34, 100),  # extra space on the right
+        'margin_pt': 5,
         'gap_pt': 0,
         'card_width_pt': 10,
         'card_height_pt': 20,
@@ -114,4 +114,4 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
-    assert [p[0] for p in positions] == [10, 0]
+    assert [p[0] for p in positions] == [19, 9]


### PR DESCRIPTION
## Summary
- calculate leftover horizontal space when drawing pages
- start back pages from right margin so backs mirror fronts
- update test to cover asymmetrical margins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846573c9b0c833191d1ba362bd3580c