### PR TITLE
Add pages intercalation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ MARGIN_MM: 5             # margin on all sides
 GAP_MM: 2                # space between cards
 DEFAULT_BACK: resources/back.jpg   # default back image
 language-default: es     # preferred language for downloads
+pages-intercalation: true # interleave front and back pages in one PDF
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").
@@ -62,7 +63,9 @@ python3 generate_pdf.py
 ```
 
 PDF files will be created inside the `results/` directory with a name based on
-the current date and time, for example `deck_20230101_120000_fronts.pdf` and
-`deck_20230101_120000_backs.pdf`. The back pages are mirrored horizontally so
-that fronts and backs line up when cutting. Print using the "flip on long edge"
-duplex option to ensure proper alignment.
+the current date and time. If `pages-intercalation` is enabled (the default) a
+single file like `deck_20230101_120000.pdf` will contain alternating front and
+back pages. Otherwise two files, `deck_20230101_120000_fronts.pdf` and
+`deck_20230101_120000_backs.pdf`, will be produced. The back pages are mirrored
+horizontally so that fronts and backs line up when cutting. Print using the
+"flip on long edge" duplex option to ensure proper alignment.

--- a/config.yml
+++ b/config.yml
@@ -4,3 +4,4 @@ MARGIN_MM: 5
 GAP_MM: 1
 DEFAULT_BACK: resources/back.jpg
 language-default: en
+pages-intercalation: true

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -115,3 +115,33 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
     gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
     assert [p[0] for p in positions] == [19, 9]
+
+
+def test_draw_pages_intercalated_order(monkeypatch, gp):
+    events = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            events.append(img)
+        def showPage(self):
+            events.append('page')
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (10, 10),
+        'margin_pt': 0,
+        'gap_pt': 0,
+        'card_width_pt': 1,
+        'card_height_pt': 1,
+        'GRID': (1, 1),
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages_intercalated('dummy.pdf', pages, cfg)
+
+    assert events == ['f1', 'page', 'b1', 'page']


### PR DESCRIPTION
## Summary
- add `pages-intercalation` option to config
- implement interleaved PDF generation when the option is true
- update README to describe the new behaviour
- add tests for intercalated page order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474c1e70448331b3662bb924cc8a28