### PR TITLE
Add horizontal back offset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ GAP_MM: 2                # space between cards
 DEFAULT_BACK: resources/back.jpg   # default back image
 language-default: es     # preferred language for downloads
 pages-intercalation: true # interleave front and back pages in one PDF
+horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").
@@ -67,5 +68,7 @@ the current date and time. If `pages-intercalation` is enabled (the default) a
 single file like `deck_20230101_120000.pdf` will contain alternating front and
 back pages. Otherwise two files, `deck_20230101_120000_fronts.pdf` and
 `deck_20230101_120000_backs.pdf`, will be produced. The back pages are mirrored
-horizontally so that fronts and backs line up when cutting. Print using the
-"flip on long edge" duplex option to ensure proper alignment.
+horizontally so that fronts and backs line up when cutting. Use the
+`horizontal-back-offset` setting to tweak their horizontal position if your
+printer is misaligned. Print using the "flip on long edge" duplex option to
+ensure proper alignment.

--- a/config.yml
+++ b/config.yml
@@ -5,3 +5,4 @@ GAP_MM: 1
 DEFAULT_BACK: resources/back.jpg
 language-default: en
 pages-intercalation: true
+horizontal-back-offset: -2

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -40,6 +40,7 @@ def load_config():
     cfg['card_width_pt'] = mm_to_pt(CARD_WIDTH_MM)
     cfg['card_height_pt'] = mm_to_pt(CARD_HEIGHT_MM)
     cfg.setdefault('pages-intercalation', True)
+    cfg['back_offset_pt'] = mm_to_pt(cfg.get('horizontal-back-offset', -2))
     return cfg
 
 
@@ -114,7 +115,7 @@ def _draw_single_page(canvas_obj, page, config, front):
         if front:
             x = margin + col * (cell_width + gap)
         else:
-            x = right_margin + (cols - 1 - col) * (cell_width + gap)
+            x = right_margin + (cols - 1 - col) * (cell_width + gap) + config.get('back_offset_pt', 0)
         y = page_height - margin - cell_height - row * (cell_height + gap)
         img_path = card['front'] if front else card['back']
         img = Image.open(img_path)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -117,6 +117,37 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
     assert [p[0] for p in positions] == [19, 9]
 
 
+def test_draw_pages_back_offset(monkeypatch, gp):
+    positions = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            positions.append((x, y))
+        def showPage(self):
+            pass
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (34, 100),
+        'margin_pt': 5,
+        'gap_pt': 0,
+        'card_width_pt': 10,
+        'card_height_pt': 20,
+        'GRID': (2, 1),
+        'back_offset_pt': 3,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}, {'front': 'f2', 'back': 'b2'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
+
+    assert [p[0] for p in positions] == [22, 12]
+
+
 def test_draw_pages_intercalated_order(monkeypatch, gp):
     events = []
 


### PR DESCRIPTION
## Summary
- make card back position adjustable with `horizontal-back-offset`
- document `horizontal-back-offset` usage
- test new configuration option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488895b558833196a3599a4f399e8c