### PR TITLE
Implement back image oversize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ DEFAULT_BACK: resources/back.jpg   # default back image
 language-default: es     # preferred language for downloads
 pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
+back-oversize: 0.2        # enlarge back images by this many mm in both width and height
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").

--- a/config.yml
+++ b/config.yml
@@ -6,3 +6,4 @@ DEFAULT_BACK: resources/back.jpg
 language-default: en
 pages-intercalation: true
 horizontal-back-offset: -2
+back-oversize: 0.2

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -41,6 +41,7 @@ def load_config():
     cfg['card_height_pt'] = mm_to_pt(CARD_HEIGHT_MM)
     cfg.setdefault('pages-intercalation', True)
     cfg['back_offset_pt'] = mm_to_pt(cfg.get('horizontal-back-offset', -2))
+    cfg['back_oversize_pt'] = mm_to_pt(cfg.get('back-oversize', 0.2))
     return cfg
 
 
@@ -116,11 +117,20 @@ def _draw_single_page(canvas_obj, page, config, front):
             x = margin + col * (cell_width + gap)
         else:
             x = right_margin + (cols - 1 - col) * (cell_width + gap) + config.get('back_offset_pt', 0)
+            x -= config.get('back_oversize_pt', 0) / 2
         y = page_height - margin - cell_height - row * (cell_height + gap)
+        if not front:
+            y -= config.get('back_oversize_pt', 0) / 2
         img_path = card['front'] if front else card['back']
         img = Image.open(img_path)
         img_reader = ImageReader(img)
-        canvas_obj.drawImage(img_reader, x, y, width=cell_width, height=cell_height)
+        if front:
+            width = cell_width
+            height = cell_height
+        else:
+            width = cell_width + config.get('back_oversize_pt', 0)
+            height = cell_height + config.get('back_oversize_pt', 0)
+        canvas_obj.drawImage(img_reader, x, y, width=width, height=height)
 
 
 def draw_pages(pdf_path, pages, config, front=True):

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -148,6 +148,37 @@ def test_draw_pages_back_offset(monkeypatch, gp):
     assert [p[0] for p in positions] == [22, 12]
 
 
+def test_draw_pages_back_oversize(monkeypatch, gp):
+    sizes = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            sizes.append((width, height))
+        def showPage(self):
+            pass
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (34, 100),
+        'margin_pt': 5,
+        'gap_pt': 0,
+        'card_width_pt': 10,
+        'card_height_pt': 20,
+        'GRID': (1, 1),
+        'back_oversize_pt': 4,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
+
+    assert sizes[0] == (14, 24)
+
+
 def test_draw_pages_intercalated_order(monkeypatch, gp):
     events = []
 


### PR DESCRIPTION
## Summary
- introduce `back-oversize` option in config and README
- add support for oversize in PDF generation
- adjust back positioning when oversizing
- test oversize behaviour in PDF output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684891b5659483319fec2b65de29ee11