### PR TITLE
Fix oversize only on back pages

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -106,6 +106,8 @@ def _draw_single_page(canvas_obj, page, config, front):
     cell_width = config['card_width_pt']
     cell_height = config['card_height_pt']
 
+    oversize = config.get('back_oversize_pt', 0) if not front else 0
+
     extra_x = page_width - 2 * margin - cols * cell_width - (cols - 1) * gap
     extra_x = max(0, extra_x)
     right_margin = margin + extra_x
@@ -117,10 +119,9 @@ def _draw_single_page(canvas_obj, page, config, front):
             x = margin + col * (cell_width + gap)
         else:
             x = right_margin + (cols - 1 - col) * (cell_width + gap) + config.get('back_offset_pt', 0)
-            x -= config.get('back_oversize_pt', 0) / 2
+        x -= oversize / 2
         y = page_height - margin - cell_height - row * (cell_height + gap)
-        if not front:
-            y -= config.get('back_oversize_pt', 0) / 2
+        y -= oversize / 2
         img_path = card['front'] if front else card['back']
         img = Image.open(img_path)
         img_reader = ImageReader(img)
@@ -128,8 +129,8 @@ def _draw_single_page(canvas_obj, page, config, front):
             width = cell_width
             height = cell_height
         else:
-            width = cell_width + config.get('back_oversize_pt', 0)
-            height = cell_height + config.get('back_oversize_pt', 0)
+            width = cell_width + oversize
+            height = cell_height + oversize
         canvas_obj.drawImage(img_reader, x, y, width=width, height=height)
 
 

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -179,6 +179,37 @@ def test_draw_pages_back_oversize(monkeypatch, gp):
     assert sizes[0] == (14, 24)
 
 
+def test_draw_pages_front_no_oversize(monkeypatch, gp):
+    sizes = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            sizes.append((width, height))
+        def showPage(self):
+            pass
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (34, 100),
+        'margin_pt': 5,
+        'gap_pt': 0,
+        'card_width_pt': 10,
+        'card_height_pt': 20,
+        'GRID': (1, 1),
+        'back_oversize_pt': 4,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+
+    assert sizes[0] == (10, 20)
+
+
 def test_draw_pages_intercalated_order(monkeypatch, gp):
     events = []
 


### PR DESCRIPTION
## Summary
- ensure back oversizing isn't applied when drawing front pages
- add a test verifying front pages are drawn at normal size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b00cb89883319c59058ee71a6b1e