### PR TITLE
Add set+collector support

### DIFF
--- a/tests/test_fetch_images.py
+++ b/tests/test_fetch_images.py
@@ -62,3 +62,44 @@ def test_fetch_single_card_lang(monkeypatch, fi, tmp_path):
     fi._fetch_single_card(1, 'Island', 'es')
     assert downloaded
     assert downloaded[0].endswith('lang=es')
+
+
+def test_parse_card_list_extended(fi, tmp_path):
+    data = (
+        "1 Arcane Signet (FIC) 335\n"
+        "2 Swamp\n"
+        "1 Beast Within (PLST) BBD-190\n"
+    )
+    path = tmp_path / "cards.txt"
+    path.write_text(data)
+
+    cards = fi.parse_card_list(str(path))
+
+    assert cards == [
+        (1, 'Arcane Signet', 'FIC', '335'),
+        (2, 'Swamp', None, None),
+        (1, 'Beast Within', 'PLST', 'BBD-190'),
+    ]
+
+
+def test_fetch_single_card_with_set_and_collector(monkeypatch, fi, tmp_path):
+    data = {
+        'lang': 'en',
+        'image_uris': {'png': 'http://img/image.png'},
+        'name': 'Island',
+    }
+
+    called = {}
+
+    def fake_get(url, params=None):
+        called['url'] = url
+        called['params'] = params
+        return DummyResp(data)
+
+    monkeypatch.setattr(fi.requests, 'get', fake_get)
+    monkeypatch.setattr(fi, 'download_image', lambda u, d: None)
+
+    fi._fetch_single_card(1, 'Island', 'en', set_code='m20', collector='123')
+
+    assert called['url'].startswith('https://api.scryfall.com/cards/m20/123/en')
+    assert called['params'] is None


### PR DESCRIPTION
## Summary
- parse card list lines with optional set and collector number
- support fetching cards by set and collector number via Scryfall
- expand tests for new parsing and fetching behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495447cd548331b77539bf007587fc