### PR TITLE
Handle *F* flag in card list

### DIFF
--- a/fetch_images.py
+++ b/fetch_images.py
@@ -34,13 +34,17 @@ def parse_card_list(path=CARD_LIST_FILE):
         ``1 Card Name (SET)``
         ``1 Card Name (SET) 123``
         ``1 Card Name (SET) ABC-123``
+    A trailing ``*F*`` flag is ignored, e.g. ``1 Card Name (SET) 123 *F*``.
     """
 
     cards = []
     if not os.path.exists(path):
         return cards
 
-    line_re = re.compile(r"^(\d+)\s+(.*?)(?:\s+\(([^)]+)\))?(?:\s+([^\s]+))?$")
+    line_re = re.compile(
+        r"^(\d+)\s+(.*?)(?:\s+\(([^)]+)\))?(?:\s+([^\s]+))?(?:\s+\*F\*)?$",
+        re.IGNORECASE,
+    )
 
     with open(path, 'r', encoding='utf-8') as f:
         for line in f:

--- a/tests/test_fetch_images.py
+++ b/tests/test_fetch_images.py
@@ -82,6 +82,18 @@ def test_parse_card_list_extended(fi, tmp_path):
     ]
 
 
+def test_parse_card_list_ignore_f_flag(fi, tmp_path):
+    data = "1 Altered Ego (FIC) 317 *F*\n"
+    path = tmp_path / "cards.txt"
+    path.write_text(data)
+
+    cards = fi.parse_card_list(str(path))
+
+    assert cards == [
+        (1, 'Altered Ego', 'FIC', '317'),
+    ]
+
+
 def test_fetch_single_card_with_set_and_collector(monkeypatch, fi, tmp_path):
     data = {
         'lang': 'en',


### PR DESCRIPTION
## Summary
- handle optional `*F*` marker in card list parser
- document the new behaviour
- test that the flag is ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849569c335083319c525be77f9f1d16