### PR TITLE
Add vertical back offset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ DEFAULT_BACK: resources/back.jpg   # default back image
 language-default: es     # preferred language for downloads
 pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
+vertical-back-offset: 0  # vertical shift in mm for backs (positive = up)
 back-oversize: 0.2        # enlarge back images by this many mm in both width and height
 ```
 
@@ -71,5 +72,6 @@ back pages. Otherwise two files, `deck_20230101_120000_fronts.pdf` and
 `deck_20230101_120000_backs.pdf`, will be produced. The back pages are mirrored
 horizontally so that fronts and backs line up when cutting. Use the
 `horizontal-back-offset` setting to tweak their horizontal position if your
-printer is misaligned. Print using the "flip on long edge" duplex option to
+printer is misaligned. Likewise, adjust `vertical-back-offset` for vertical
+alignment issues. Print using the "flip on long edge" duplex option to
 ensure proper alignment.

--- a/config.yml
+++ b/config.yml
@@ -6,4 +6,5 @@ DEFAULT_BACK: resources/back.jpg
 language-default: en
 pages-intercalation: true
 horizontal-back-offset: -2
+vertical-back-offset: 0
 back-oversize: 0.2

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -41,6 +41,7 @@ def load_config():
     cfg['card_height_pt'] = mm_to_pt(CARD_HEIGHT_MM)
     cfg.setdefault('pages-intercalation', True)
     cfg['back_offset_pt'] = mm_to_pt(cfg.get('horizontal-back-offset', -2))
+    cfg['vertical_back_offset_pt'] = mm_to_pt(cfg.get('vertical-back-offset', 0))
     cfg['back_oversize_pt'] = mm_to_pt(cfg.get('back-oversize', 0.2))
     return cfg
 
@@ -121,6 +122,8 @@ def _draw_single_page(canvas_obj, page, config, front):
             x = right_margin + (cols - 1 - col) * (cell_width + gap) + config.get('back_offset_pt', 0)
         x -= oversize / 2
         y = page_height - margin - cell_height - row * (cell_height + gap)
+        if not front:
+            y += config.get('vertical_back_offset_pt', 0)
         y -= oversize / 2
         img_path = card['front'] if front else card['back']
         img = Image.open(img_path)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -148,6 +148,37 @@ def test_draw_pages_back_offset(monkeypatch, gp):
     assert [p[0] for p in positions] == [22, 12]
 
 
+def test_draw_pages_vertical_back_offset(monkeypatch, gp):
+    positions = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, img, x, y, width=None, height=None):
+            positions.append((x, y))
+        def showPage(self):
+            pass
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (34, 100),
+        'margin_pt': 5,
+        'gap_pt': 0,
+        'card_width_pt': 10,
+        'card_height_pt': 20,
+        'GRID': (1, 2),
+        'vertical_back_offset_pt': 4,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}, {'front': 'f2', 'back': 'b2'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
+
+    assert [p[1] for p in positions] == [79, 59]
+
+
 def test_draw_pages_back_oversize(monkeypatch, gp):
     sizes = []
 


### PR DESCRIPTION
## Summary
- allow adjusting vertical offset for backs of cards
- document `vertical-back-offset` in README
- support config value in `generate_pdf.py`
- test new vertical offset behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ada36ab788331a504d413add146c0