### PR TITLE
Add page rotation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
 vertical-back-offset: 0  # vertical shift in mm for backs (positive = up)
 back-oversize: 0.2        # enlarge back images by this many mm in both width and height
+page-rotation-degrees: 0  # rotate each page this many degrees around the center
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").

--- a/config.yml
+++ b/config.yml
@@ -8,3 +8,4 @@ pages-intercalation: true
 horizontal-back-offset: -2
 vertical-back-offset: 0
 back-oversize: 0.2
+page-rotation-degrees: 0

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -43,6 +43,7 @@ def load_config():
     cfg['back_offset_pt'] = mm_to_pt(cfg.get('horizontal-back-offset', -2))
     cfg['vertical_back_offset_pt'] = mm_to_pt(cfg.get('vertical-back-offset', 0))
     cfg['back_oversize_pt'] = mm_to_pt(cfg.get('back-oversize', 0.2))
+    cfg['page_rotation_deg'] = cfg.get('page-rotation-degrees', 0)
     return cfg
 
 
@@ -106,6 +107,12 @@ def _draw_single_page(canvas_obj, page, config, front):
     page_width, page_height = page_size
     cell_width = config['card_width_pt']
     cell_height = config['card_height_pt']
+    angle = config.get('page_rotation_deg', 0)
+
+    canvas_obj.saveState()
+    canvas_obj.translate(page_width/2, page_height/2)
+    canvas_obj.rotate(angle)
+    canvas_obj.translate(-page_width/2, -page_height/2)
 
     oversize = config.get('back_oversize_pt', 0) if not front else 0
 
@@ -135,6 +142,8 @@ def _draw_single_page(canvas_obj, page, config, front):
             width = cell_width + oversize
             height = cell_height + oversize
         canvas_obj.drawImage(img_reader, x, y, width=width, height=height)
+
+    canvas_obj.restoreState()
 
 
 def draw_pages(pdf_path, pages, config, front=True):

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -26,6 +26,14 @@ def stub_dependencies(monkeypatch):
             pass
         def showPage(self):
             pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
+            pass
         def save(self):
             pass
 
@@ -97,6 +105,14 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
             positions.append((x, y))
         def showPage(self):
             pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
+            pass
         def save(self):
             pass
 
@@ -126,6 +142,14 @@ def test_draw_pages_back_offset(monkeypatch, gp):
         def drawImage(self, img, x, y, width=None, height=None):
             positions.append((x, y))
         def showPage(self):
+            pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
             pass
         def save(self):
             pass
@@ -158,6 +182,14 @@ def test_draw_pages_vertical_back_offset(monkeypatch, gp):
             positions.append((x, y))
         def showPage(self):
             pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
+            pass
         def save(self):
             pass
 
@@ -188,6 +220,14 @@ def test_draw_pages_back_oversize(monkeypatch, gp):
         def drawImage(self, img, x, y, width=None, height=None):
             sizes.append((width, height))
         def showPage(self):
+            pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
             pass
         def save(self):
             pass
@@ -220,6 +260,14 @@ def test_draw_pages_front_no_oversize(monkeypatch, gp):
             sizes.append((width, height))
         def showPage(self):
             pass
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
+            pass
         def save(self):
             pass
 
@@ -251,6 +299,14 @@ def test_draw_pages_intercalated_order(monkeypatch, gp):
             events.append(img)
         def showPage(self):
             events.append('page')
+        def saveState(self):
+            pass
+        def translate(self, *args, **kwargs):
+            pass
+        def rotate(self, *args, **kwargs):
+            pass
+        def restoreState(self):
+            pass
         def save(self):
             pass
 
@@ -269,3 +325,42 @@ def test_draw_pages_intercalated_order(monkeypatch, gp):
     gp.draw_pages_intercalated('dummy.pdf', pages, cfg)
 
     assert events == ['f1', 'page', 'b1', 'page']
+
+
+def test_page_rotation(monkeypatch, gp):
+    calls = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, *a, **k):
+            pass
+        def showPage(self):
+            pass
+        def saveState(self):
+            calls.append('saveState')
+        def translate(self, x, y):
+            calls.append(('translate', x, y))
+        def rotate(self, angle):
+            calls.append(('rotate', angle))
+        def restoreState(self):
+            calls.append('restoreState')
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (10, 10),
+        'margin_pt': 0,
+        'gap_pt': 0,
+        'card_width_pt': 1,
+        'card_height_pt': 1,
+        'GRID': (1, 1),
+        'page_rotation_deg': 45,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+
+    assert ('rotate', 45) in calls


### PR DESCRIPTION
## Summary
- allow rotating output pages with `page-rotation-degrees` config option
- rotate canvas in `_draw_single_page`
- document new config entry
- test that canvas.rotate is invoked when a rotation angle is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adc8c3ab083318d21b23f521ac983