### PR TITLE
Improve card list parsing

### DIFF
--- a/fetch_images.py
+++ b/fetch_images.py
@@ -42,7 +42,7 @@ def parse_card_list(path=CARD_LIST_FILE):
         return cards
 
     line_re = re.compile(
-        r"^(\d+)\s+(.*?)(?:\s+\(([^)]+)\))?(?:\s+([^\s]+))?(?:\s+\*F\*)?$",
+        r"^(\d+)\s+(.*?)(?:\s+\(([^)]+)\)(?:\s+([^\s]+))?)?(?:\s+\*F\*)?$",
         re.IGNORECASE,
     )
 

--- a/tests/test_fetch_images.py
+++ b/tests/test_fetch_images.py
@@ -94,6 +94,18 @@ def test_parse_card_list_ignore_f_flag(fi, tmp_path):
     ]
 
 
+def test_parse_card_list_no_set(fi, tmp_path):
+    data = "1 Baleful Strix\n"
+    path = tmp_path / "cards.txt"
+    path.write_text(data)
+
+    cards = fi.parse_card_list(str(path))
+
+    assert cards == [
+        (1, 'Baleful Strix', None, None),
+    ]
+
+
 def test_fetch_single_card_with_set_and_collector(monkeypatch, fi, tmp_path):
     data = {
         'lang': 'en',


### PR DESCRIPTION
## Summary
- fix regex for parsing card lines so collector number is optional only if set code is provided
- test parse_card_list with line lacking a set code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b03cc3b9883318560ce9a0384c21b