### PR TITLE
Fix page rotation direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
 vertical-back-offset: 0  # vertical shift in mm for backs (positive = up)
 back-oversize: 0.2        # enlarge back images by this many mm in both width and height
-page-rotation-degrees: 0  # rotate each page this many degrees around the center
+page-rotation-degrees: 0  # positive = clockwise, negative = counter-clockwise
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -107,11 +107,15 @@ def _draw_single_page(canvas_obj, page, config, front):
     page_width, page_height = page_size
     cell_width = config['card_width_pt']
     cell_height = config['card_height_pt']
-    angle = config.get('page_rotation_deg', 0)
+    angle = float(config.get('page_rotation_deg', 0))
+
+    # ReportLab rotates counter-clockwise for positive angles. In the
+    # configuration we define positive values as clockwise to be more
+    # intuitive, so we invert the sign here.
 
     canvas_obj.saveState()
     canvas_obj.translate(page_width/2, page_height/2)
-    canvas_obj.rotate(angle)
+    canvas_obj.rotate(-angle)
     canvas_obj.translate(-page_width/2, -page_height/2)
 
     oversize = config.get('back_oversize_pt', 0) if not front else 0

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -363,4 +363,43 @@ def test_page_rotation(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=True)
 
-    assert ('rotate', 45) in calls
+    assert ('rotate', -45.0) in calls
+
+
+def test_page_rotation_negative(monkeypatch, gp):
+    calls = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, *a, **k):
+            pass
+        def showPage(self):
+            pass
+        def saveState(self):
+            calls.append('saveState')
+        def translate(self, x, y):
+            calls.append(('translate', x, y))
+        def rotate(self, angle):
+            calls.append(('rotate', angle))
+        def restoreState(self):
+            calls.append('restoreState')
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (10, 10),
+        'margin_pt': 0,
+        'gap_pt': 0,
+        'card_width_pt': 1,
+        'card_height_pt': 1,
+        'GRID': (1, 1),
+        'page_rotation_deg': -30,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+
+    assert ('rotate', 30.0) in calls


### PR DESCRIPTION
## Summary
- invert sign of page rotation so positive values rotate clockwise
- clarify rotation sign usage in README
- update tests for new rotation logic
- add test for negative rotation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0f3806088331b41cd574d8018704