### PR TITLE
Adjust rotation to always use positive angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
 vertical-back-offset: 0  # vertical shift in mm for backs (positive = up)
 back-oversize: 0.2        # enlarge back images by this many mm in both width and height
-page-rotation-degrees: 0  # positive = clockwise, negative = counter-clockwise
+page-rotation-degrees: 0  # rotation applied as ``360 - value`` so the argument sent
+                           # to ReportLab is always positive
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -109,13 +109,16 @@ def _draw_single_page(canvas_obj, page, config, front):
     cell_height = config['card_height_pt']
     angle = float(config.get('page_rotation_deg', 0))
 
-    # ReportLab rotates counter-clockwise for positive angles. In the
-    # configuration we define positive values as clockwise to be more
-    # intuitive, so we invert the sign here.
+    # ReportLab rotates counter-clockwise for positive values. The project
+    # configuration defines positive numbers as clockwise, but we also want to
+    # avoid passing negative angles to ``rotate``. To keep the same visual
+    # result while ensuring the argument is always positive, we transform the
+    # value using ``360 - angle``.
+    angle = 360 - angle
 
     canvas_obj.saveState()
     canvas_obj.translate(page_width/2, page_height/2)
-    canvas_obj.rotate(-angle)
+    canvas_obj.rotate(angle)
     canvas_obj.translate(-page_width/2, -page_height/2)
 
     oversize = config.get('back_oversize_pt', 0) if not front else 0

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -363,7 +363,7 @@ def test_page_rotation(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=True)
 
-    assert ('rotate', -45.0) in calls
+    assert ('rotate', 315.0) in calls
 
 
 def test_page_rotation_negative(monkeypatch, gp):
@@ -402,4 +402,4 @@ def test_page_rotation_negative(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=True)
 
-    assert ('rotate', 30.0) in calls
+    assert ('rotate', 390.0) in calls


### PR DESCRIPTION
## Summary
- rotate pages using `360 - angle` so reportlab never receives negative values
- document rotation logic in README
- update tests for new rotation approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1947301c8331a4d7d991ace6fa7a