### PR TITLE
Fix page rotation logic for negative angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ pages-intercalation: true # interleave front and back pages in one PDF
 horizontal-back-offset: -2 # horizontal shift in mm for backs (negative = left)
 vertical-back-offset: 0  # vertical shift in mm for backs (positive = up)
 back-oversize: 0.2        # enlarge back images by this many mm in both width and height
-page-rotation-degrees: 0  # rotation applied as ``360 - value`` so the argument sent
-                           # to ReportLab is always positive
+page-rotation-degrees: 0  # rotation in degrees. Negative values are transformed
+                           # using ``360 - value`` so the argument passed to
+                           # ReportLab is always positive
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -109,12 +109,13 @@ def _draw_single_page(canvas_obj, page, config, front):
     cell_height = config['card_height_pt']
     angle = float(config.get('page_rotation_deg', 0))
 
-    # ReportLab rotates counter-clockwise for positive values. The project
-    # configuration defines positive numbers as clockwise, but we also want to
-    # avoid passing negative angles to ``rotate``. To keep the same visual
-    # result while ensuring the argument is always positive, we transform the
-    # value using ``360 - angle``.
-    angle = 360 - angle
+    # ReportLab rotates counter-clockwise for positive values.  The
+    # configuration may include negative numbers for clockwise rotation.
+    # ``rotate`` does not accept negative values, so for negative angles we
+    # convert them using ``360 - angle`` to preserve the desired orientation
+    # while keeping the argument positive.  Positive values are used as-is.
+    if angle < 0:
+        angle = 360 - angle
 
     canvas_obj.saveState()
     canvas_obj.translate(page_width/2, page_height/2)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -363,7 +363,7 @@ def test_page_rotation(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=True)
 
-    assert ('rotate', 315.0) in calls
+    assert ('rotate', 45.0) in calls
 
 
 def test_page_rotation_negative(monkeypatch, gp):


### PR DESCRIPTION
## Summary
- adjust page rotation so negative angles are mapped using `360 - angle`
- update README instructions about page rotation
- fix tests for new rotation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1d5c6484833186add34a7bd21918