### PR TITLE
Rotate only back pages

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -107,7 +107,7 @@ def _draw_single_page(canvas_obj, page, config, front):
     page_width, page_height = page_size
     cell_width = config['card_width_pt']
     cell_height = config['card_height_pt']
-    angle = float(config.get('page_rotation_deg', 0))
+    angle = float(config.get('page_rotation_deg', 0)) if not front else 0
 
     # ReportLab rotates counter-clockwise for positive values.  The
     # configuration may include negative numbers for clockwise rotation.
@@ -119,7 +119,8 @@ def _draw_single_page(canvas_obj, page, config, front):
 
     canvas_obj.saveState()
     canvas_obj.translate(page_width/2, page_height/2)
-    canvas_obj.rotate(angle)
+    if angle:
+        canvas_obj.rotate(angle)
     canvas_obj.translate(-page_width/2, -page_height/2)
 
     oversize = config.get('back_oversize_pt', 0) if not front else 0

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -361,7 +361,7 @@ def test_page_rotation(monkeypatch, gp):
     }
     pages = [[{'front': 'f1', 'back': 'b1'}]]
 
-    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
     assert ('rotate', 45.0) in calls
 
@@ -400,6 +400,45 @@ def test_page_rotation_negative(monkeypatch, gp):
     }
     pages = [[{'front': 'f1', 'back': 'b1'}]]
 
-    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+    gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
     assert ('rotate', 390.0) in calls
+
+
+def test_page_rotation_front_unchanged(monkeypatch, gp):
+    calls = []
+
+    class RecCanvas:
+        def __init__(self, *a, **k):
+            pass
+        def drawImage(self, *a, **k):
+            pass
+        def showPage(self):
+            pass
+        def saveState(self):
+            calls.append('saveState')
+        def translate(self, x, y):
+            calls.append(('translate', x, y))
+        def rotate(self, angle):
+            calls.append(('rotate', angle))
+        def restoreState(self):
+            calls.append('restoreState')
+        def save(self):
+            pass
+
+    monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
+
+    cfg = {
+        'page_size': (10, 10),
+        'margin_pt': 0,
+        'gap_pt': 0,
+        'card_width_pt': 1,
+        'card_height_pt': 1,
+        'GRID': (1, 1),
+        'page_rotation_deg': 45,
+    }
+    pages = [[{'front': 'f1', 'back': 'b1'}]]
+
+    gp.draw_pages('dummy.pdf', pages, cfg, front=True)
+
+    assert not any(call[0] == 'rotate' for call in calls if isinstance(call, tuple))


### PR DESCRIPTION
## Summary
- rotate only back pages when rendering PDF
- update tests for back-only rotation
- add test to ensure no rotation for front pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1e7095248331828781e11386f04c