### PR TITLE
Add card centering and calibration features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ back-oversize: 0.2        # enlarge back images by this many mm in both width an
 page-rotation-degrees: 0  # rotation in degrees. Negative values are transformed
                            # using ``360 - value`` so the argument passed to
                            # ReportLab is always positive
+guided-lines: true        # draw thin grey cutting guides on fronts
+cross-calibrator: false   # draw small calibration crosses on every corner
 ```
 
 Cards are printed at the official size of 63.5mm × 88.9mm (2.5" × 3.5").
@@ -78,3 +80,9 @@ horizontally so that fronts and backs line up when cutting. Use the
 printer is misaligned. Likewise, adjust `vertical-back-offset` for vertical
 alignment issues. Print using the "flip on long edge" duplex option to
 ensure proper alignment.
+
+To generate a page containing only calibration crosses use:
+
+```bash
+python3 generate_calibration_page.py
+```

--- a/config.yml
+++ b/config.yml
@@ -9,3 +9,5 @@ horizontal-back-offset: -2
 vertical-back-offset: 0
 back-oversize: 0.2
 page-rotation-degrees: 0
+guided-lines: true
+cross-calibrator: false

--- a/generate_calibration_page.py
+++ b/generate_calibration_page.py
@@ -1,0 +1,39 @@
+import os
+from datetime import datetime
+from reportlab.pdfgen import canvas
+from generate_pdf import load_config, RESULTS_DIR, _draw_crosses
+
+
+def _single_page(c, config, front):
+    page_width, page_height = config['page_size']
+    angle = float(config.get('page_rotation_deg', 0)) if not front else 0
+    if angle < 0:
+        angle = 360 - angle
+    c.saveState()
+    c.translate(page_width/2, page_height/2)
+    if angle:
+        c.rotate(angle)
+    c.translate(-page_width/2, -page_height/2)
+    x_off = config.get('back_offset_pt', 0) if not front else 0
+    y_off = config.get('vertical_back_offset_pt', 0) if not front else 0
+    cfg = dict(config)
+    cfg['_force_cross'] = True
+    _draw_crosses(c, cfg, front, x_off, y_off)
+    c.restoreState()
+
+
+def draw_calibration(pdf_path, config):
+    c = canvas.Canvas(pdf_path, pagesize=config['page_size'])
+    _single_page(c, config, True)
+    c.showPage()
+    _single_page(c, config, False)
+    c.showPage()
+    c.save()
+
+
+if __name__ == '__main__':
+    cfg = load_config()
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    pdf_path = os.path.join(RESULTS_DIR, f'calibration_{timestamp}.pdf')
+    draw_calibration(pdf_path, cfg)

--- a/tests/test_generate_pdf.py
+++ b/tests/test_generate_pdf.py
@@ -36,6 +36,18 @@ def stub_dependencies(monkeypatch):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     rl.pdfgen.canvas = types.SimpleNamespace(Canvas=DummyCanvas)
     rl.lib = types.ModuleType('lib')
@@ -115,6 +127,14 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -130,7 +150,7 @@ def test_draw_pages_back_mirrored(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
-    assert [p[0] for p in positions] == [19, 9]
+    assert [p[0] for p in positions] == [17, 7]
 
 
 def test_draw_pages_back_offset(monkeypatch, gp):
@@ -153,6 +173,14 @@ def test_draw_pages_back_offset(monkeypatch, gp):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -169,7 +197,7 @@ def test_draw_pages_back_offset(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
-    assert [p[0] for p in positions] == [22, 12]
+    assert [p[0] for p in positions] == [20, 10]
 
 
 def test_draw_pages_vertical_back_offset(monkeypatch, gp):
@@ -192,6 +220,14 @@ def test_draw_pages_vertical_back_offset(monkeypatch, gp):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -208,7 +244,7 @@ def test_draw_pages_vertical_back_offset(monkeypatch, gp):
 
     gp.draw_pages('dummy.pdf', pages, cfg, front=False)
 
-    assert [p[1] for p in positions] == [79, 59]
+    assert [p[1] for p in positions] == [54, 34]
 
 
 def test_draw_pages_back_oversize(monkeypatch, gp):
@@ -230,6 +266,14 @@ def test_draw_pages_back_oversize(monkeypatch, gp):
         def restoreState(self):
             pass
         def save(self):
+            pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
             pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
@@ -270,6 +314,14 @@ def test_draw_pages_front_no_oversize(monkeypatch, gp):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -309,6 +361,14 @@ def test_draw_pages_intercalated_order(monkeypatch, gp):
             pass
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -346,6 +406,14 @@ def test_page_rotation(monkeypatch, gp):
         def restoreState(self):
             calls.append('restoreState')
         def save(self):
+            pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
             pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
@@ -386,6 +454,14 @@ def test_page_rotation_negative(monkeypatch, gp):
             calls.append('restoreState')
         def save(self):
             pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
+            pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)
 
@@ -424,6 +500,14 @@ def test_page_rotation_front_unchanged(monkeypatch, gp):
         def restoreState(self):
             calls.append('restoreState')
         def save(self):
+            pass
+        def setStrokeGray(self, *a, **k):
+            pass
+        def setLineWidth(self, *a, **k):
+            pass
+        def setStrokeColorRGB(self, *a, **k):
+            pass
+        def line(self, *a, **k):
             pass
 
     monkeypatch.setattr(gp.canvas, 'Canvas', RecCanvas)


### PR DESCRIPTION
## Summary
- center cards in generated PDFs
- add guided cutting lines and calibration crosses
- include config settings for `guided-lines` and `cross-calibrator`
- implement command to generate calibration-only PDF
- adjust tests for new drawing methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f58b1b1c48331aa9279f6e9fbaad9