### PR TITLE
Support token set codes in brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Create a `card-list.txt` file listing the cards to download:
 ```
 2 Swamp
 3 Island
+1 Beast [tfdn]
 ```
+
+Use square brackets to specify the set code for tokens. This allows
+distinguishing tokens with the same name from different sets.
 
 Run the downloader to populate `resources/deck/` with the required images:
 

--- a/fetch_images.py
+++ b/fetch_images.py
@@ -42,7 +42,7 @@ def parse_card_list(path=CARD_LIST_FILE):
         return cards
 
     line_re = re.compile(
-        r"^(\d+)\s+(.*?)(?:\s+\(([^)]+)\)(?:\s+([^\s]+))?)?(?:\s+\*F\*)?$",
+        r"^(\d+)\s+(.*?)(?:\s+(?:\(([^)]+)\)|\[([^\]]+)\])(?:\s+([^\s]+))?)?(?:\s+\*F\*)?$",
         re.IGNORECASE,
     )
 
@@ -56,8 +56,8 @@ def parse_card_list(path=CARD_LIST_FILE):
                 continue
             qty = int(m.group(1))
             name = m.group(2).strip()
-            set_code = m.group(3)
-            collector = m.group(4)
+            set_code = m.group(3) or m.group(4)
+            collector = m.group(5)
             cards.append((qty, name, set_code, collector))
     return cards
 

--- a/tests/test_fetch_images.py
+++ b/tests/test_fetch_images.py
@@ -106,6 +106,18 @@ def test_parse_card_list_no_set(fi, tmp_path):
     ]
 
 
+def test_parse_card_list_bracket_set(fi, tmp_path):
+    data = "1 Beast [tfdn]\n"
+    path = tmp_path / "cards.txt"
+    path.write_text(data)
+
+    cards = fi.parse_card_list(str(path))
+
+    assert cards == [
+        (1, 'Beast', 'tfdn', None),
+    ]
+
+
 def test_fetch_single_card_with_set_and_collector(monkeypatch, fi, tmp_path):
     data = {
         'lang': 'en',


### PR DESCRIPTION
## Summary
- support token set codes in brackets when parsing `card-list.txt`
- add unit test for new bracket notation
- document bracket set notation for tokens in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f892619c8331a4bb4bcc6f9a33b6